### PR TITLE
Fix "given that our current speeds are within ~1.5 of the speed of light"

### DIFF
--- a/primer-on-latency-and-bandwidth/index.html
+++ b/primer-on-latency-and-bandwidth/index.html
@@ -735,7 +735,7 @@ id="router-co" href="#router"></a>
       quality of the fiber links could be improved to get us a little closer to
       the speed of light: better materials with lower refractive index and
       faster routers along the way. However, given that our current speeds are
-      within ~1.5 of the speed of light, the most we can expect from this
+      within ~2/3 of the speed of light, the most we can expect from this
       strategy is just a modest 30% improvement. Unfortunately, there is simply
       no way around the laws of physics: the speed of light places a hard limit
       on the minimum latency.


### PR DESCRIPTION
In the sentence

> However, given that our current speeds are within ~1.5 of the speed of light, the most we can expect from this strategy is just a modest 30% improvement.

there is a factual mistake, possibly just a typo. It's impossible to reach 1.5x speed of light. Moreover, the matter is 1/1.5 of speed of light, which is 2/3.

Because there are many ways to express it ("2/3", "66%", "two thirds", "0.67"), and the origin of "2/3" might not be explicitly clear to readers, I'd suggest also adding a remark, a reference to the average refractive index of fiber-optic cable material.

And of course there's a chance I'm insane and the sentence is actually right. In which case you're welcome to just close this PR, I don't mind.

Thanks!